### PR TITLE
Fix one copyright text and all license links

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    @license see LICENCE.TXT
+    @license see LICENSE.txt
     @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
  -->
 <ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    @copyright Copyright (c) 2018 Payvision B.V. (https://www.payvision.com/)
     @license see LICENCE.TXT
+    @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
  -->
 <ruleset>
     <!-- include root folder of project -->

--- a/src/Application/Payments/Service/RequestBuilder.php
+++ b/src/Application/Payments/Service/RequestBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Application/Reflection/JsonToObject.php
+++ b/src/Application/Reflection/JsonToObject.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Application\Reflection;

--- a/src/Application/Request/Builder.php
+++ b/src/Application/Request/Builder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Application\Request;

--- a/src/Application/Webhook/Service/EventBuilder.php
+++ b/src/Application/Webhook/Service/EventBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Application\Webhook\Service;

--- a/src/DataType/AbstractCode.php
+++ b/src/DataType/AbstractCode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\DataType;

--- a/src/DataType/CountryCode.php
+++ b/src/DataType/CountryCode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\DataType;

--- a/src/DataType/CurrencyCode.php
+++ b/src/DataType/CurrencyCode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\DataType;

--- a/src/DataType/DataType.php
+++ b/src/DataType/DataType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\DataType;

--- a/src/DataType/LanguageCode.php
+++ b/src/DataType/LanguageCode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\DataType;

--- a/src/DataType/LimitedString.php
+++ b/src/DataType/LimitedString.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\DataType;

--- a/src/DataType/NonNegativeAmount.php
+++ b/src/DataType/NonNegativeAmount.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\DataType;

--- a/src/DataType/Url.php
+++ b/src/DataType/Url.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\DataType;

--- a/src/Domain/BrandRepository.php
+++ b/src/Domain/BrandRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Domain;

--- a/src/Domain/IssuerRepository.php
+++ b/src/Domain/IssuerRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Domain;

--- a/src/Domain/Payments/Service/Builder/Bank.php
+++ b/src/Domain/Payments/Service/Builder/Bank.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/BasicResponseBank.php
+++ b/src/Domain/Payments/Service/Builder/BasicResponseBank.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/BasicResponseCard.php
+++ b/src/Domain/Payments/Service/Builder/BasicResponseCard.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/BasicResponseTransaction.php
+++ b/src/Domain/Payments/Service/Builder/BasicResponseTransaction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/BillingAddress.php
+++ b/src/Domain/Payments/Service/Builder/BillingAddress.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Card.php
+++ b/src/Domain/Payments/Service/Builder/Card.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Composite/Payment/Body.php
+++ b/src/Domain/Payments/Service/Builder/Composite/Payment/Body.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Composite/Refund/Body.php
+++ b/src/Domain/Payments/Service/Builder/Composite/Refund/Body.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Composite/Refund/ResponseBody.php
+++ b/src/Domain/Payments/Service/Builder/Composite/Refund/ResponseBody.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Composite/Refund/ResponseRequest.php
+++ b/src/Domain/Payments/Service/Builder/Composite/Refund/ResponseRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Composite/Request/Object.php
+++ b/src/Domain/Payments/Service/Builder/Composite/Request/Object.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Composite/Request/Refund.php
+++ b/src/Domain/Payments/Service/Builder/Composite/Request/Refund.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Composite/Response/Body.php
+++ b/src/Domain/Payments/Service/Builder/Composite/Response/Body.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Composite/Response/Error.php
+++ b/src/Domain/Payments/Service/Builder/Composite/Response/Error.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Composite/Response/ErrorBody.php
+++ b/src/Domain/Payments/Service/Builder/Composite/Response/ErrorBody.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Composite/Response/Redirect.php
+++ b/src/Domain/Payments/Service/Builder/Composite/Response/Redirect.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Composite/Response/Request.php
+++ b/src/Domain/Payments/Service/Builder/Composite/Response/Request.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Customer.php
+++ b/src/Domain/Payments/Service/Builder/Customer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Dba.php
+++ b/src/Domain/Payments/Service/Builder/Dba.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/ErrorObject.php
+++ b/src/Domain/Payments/Service/Builder/ErrorObject.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Option.php
+++ b/src/Domain/Payments/Service/Builder/Option.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Payment/Body.php
+++ b/src/Domain/Payments/Service/Builder/Payment/Body.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Payment/Header.php
+++ b/src/Domain/Payments/Service/Builder/Payment/Header.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Qr.php
+++ b/src/Domain/Payments/Service/Builder/Qr.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Refund/Body.php
+++ b/src/Domain/Payments/Service/Builder/Refund/Body.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Refund/ResponseBody.php
+++ b/src/Domain/Payments/Service/Builder/Refund/ResponseBody.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Refund/ResponseRequest.php
+++ b/src/Domain/Payments/Service/Builder/Refund/ResponseRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Refund/ResponseTransaction.php
+++ b/src/Domain/Payments/Service/Builder/Refund/ResponseTransaction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Refund/Transaction.php
+++ b/src/Domain/Payments/Service/Builder/Refund/Transaction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Request/Object.php
+++ b/src/Domain/Payments/Service/Builder/Request/Object.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Request/Refund.php
+++ b/src/Domain/Payments/Service/Builder/Request/Refund.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Response/Bank.php
+++ b/src/Domain/Payments/Service/Builder/Response/Bank.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Response/Body.php
+++ b/src/Domain/Payments/Service/Builder/Response/Body.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Response/Card.php
+++ b/src/Domain/Payments/Service/Builder/Response/Card.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Response/Error.php
+++ b/src/Domain/Payments/Service/Builder/Response/Error.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Response/ErrorBody.php
+++ b/src/Domain/Payments/Service/Builder/Response/ErrorBody.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Response/Fields.php
+++ b/src/Domain/Payments/Service/Builder/Response/Fields.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Response/Header.php
+++ b/src/Domain/Payments/Service/Builder/Response/Header.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Response/Qr.php
+++ b/src/Domain/Payments/Service/Builder/Response/Qr.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Response/Redirect.php
+++ b/src/Domain/Payments/Service/Builder/Response/Redirect.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Response/Request.php
+++ b/src/Domain/Payments/Service/Builder/Response/Request.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Response/ThreeDSecure.php
+++ b/src/Domain/Payments/Service/Builder/Response/ThreeDSecure.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Response/Token.php
+++ b/src/Domain/Payments/Service/Builder/Response/Token.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Response/Transaction.php
+++ b/src/Domain/Payments/Service/Builder/Response/Transaction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/ShippingAddress.php
+++ b/src/Domain/Payments/Service/Builder/ShippingAddress.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/ThreeDSecure.php
+++ b/src/Domain/Payments/Service/Builder/ThreeDSecure.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Transaction.php
+++ b/src/Domain/Payments/Service/Builder/Transaction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/Service/Builder/Wallet.php
+++ b/src/Domain/Payments/Service/Builder/Wallet.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Bank.php
+++ b/src/Domain/Payments/ValueObject/Bank.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/BasicResponseBank.php
+++ b/src/Domain/Payments/ValueObject/BasicResponseBank.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/BasicResponseCard.php
+++ b/src/Domain/Payments/ValueObject/BasicResponseCard.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/BasicResponseTransaction.php
+++ b/src/Domain/Payments/ValueObject/BasicResponseTransaction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/BillingAddress.php
+++ b/src/Domain/Payments/ValueObject/BillingAddress.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Card.php
+++ b/src/Domain/Payments/ValueObject/Card.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Customer.php
+++ b/src/Domain/Payments/ValueObject/Customer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Dba.php
+++ b/src/Domain/Payments/ValueObject/Dba.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/ErrorObject.php
+++ b/src/Domain/Payments/ValueObject/ErrorObject.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Option.php
+++ b/src/Domain/Payments/ValueObject/Option.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Payment/Body.php
+++ b/src/Domain/Payments/ValueObject/Payment/Body.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Payment/Header.php
+++ b/src/Domain/Payments/ValueObject/Payment/Header.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Qr.php
+++ b/src/Domain/Payments/ValueObject/Qr.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Refund/Body.php
+++ b/src/Domain/Payments/ValueObject/Refund/Body.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Refund/ResponseBody.php
+++ b/src/Domain/Payments/ValueObject/Refund/ResponseBody.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Refund/ResponseRequest.php
+++ b/src/Domain/Payments/ValueObject/Refund/ResponseRequest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Refund/ResponseTransaction.php
+++ b/src/Domain/Payments/ValueObject/Refund/ResponseTransaction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Refund/Transaction.php
+++ b/src/Domain/Payments/ValueObject/Refund/Transaction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Request/Object.php
+++ b/src/Domain/Payments/ValueObject/Request/Object.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Request/Refund.php
+++ b/src/Domain/Payments/ValueObject/Request/Refund.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Response/Bank.php
+++ b/src/Domain/Payments/ValueObject/Response/Bank.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Response/Body.php
+++ b/src/Domain/Payments/ValueObject/Response/Body.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Response/Card.php
+++ b/src/Domain/Payments/ValueObject/Response/Card.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Response/Error.php
+++ b/src/Domain/Payments/ValueObject/Response/Error.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Response/ErrorBody.php
+++ b/src/Domain/Payments/ValueObject/Response/ErrorBody.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Response/Fields.php
+++ b/src/Domain/Payments/ValueObject/Response/Fields.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Response/Header.php
+++ b/src/Domain/Payments/ValueObject/Response/Header.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Response/Qr.php
+++ b/src/Domain/Payments/ValueObject/Response/Qr.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Response/Redirect.php
+++ b/src/Domain/Payments/ValueObject/Response/Redirect.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Response/Request.php
+++ b/src/Domain/Payments/ValueObject/Response/Request.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Response/ThreeDSecure.php
+++ b/src/Domain/Payments/ValueObject/Response/ThreeDSecure.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Response/Token.php
+++ b/src/Domain/Payments/ValueObject/Response/Token.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Response/Transaction.php
+++ b/src/Domain/Payments/ValueObject/Response/Transaction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/ShippingAddress.php
+++ b/src/Domain/Payments/ValueObject/ShippingAddress.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/ThreeDSecure.php
+++ b/src/Domain/Payments/ValueObject/ThreeDSecure.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Transaction.php
+++ b/src/Domain/Payments/ValueObject/Transaction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Payments/ValueObject/Wallet.php
+++ b/src/Domain/Payments/ValueObject/Wallet.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  *
  * Warning! This file is auto-generated! Any changes made to this file will be deleted in the future!
  */

--- a/src/Domain/Request.php
+++ b/src/Domain/Request.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Domain;

--- a/src/Domain/Service/Builder.php
+++ b/src/Domain/Service/Builder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Domain\Service;

--- a/src/Domain/ValueObject/Brand.php
+++ b/src/Domain/ValueObject/Brand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Domain\ValueObject;

--- a/src/Domain/ValueObject/Issuer.php
+++ b/src/Domain/ValueObject/Issuer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Domain\ValueObject;

--- a/src/Domain/Webhook/Service/EventDecorator.php
+++ b/src/Domain/Webhook/Service/EventDecorator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Domain\Webhook\Service;

--- a/src/Domain/Webhook/Service/Validator.php
+++ b/src/Domain/Webhook/Service/Validator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Domain\Webhook\Service;

--- a/src/Domain/Webhook/ValueObject/Event.php
+++ b/src/Domain/Webhook/ValueObject/Event.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Domain\Webhook\ValueObject;

--- a/src/Exception/Api/ErrorResponse.php
+++ b/src/Exception/Api/ErrorResponse.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Exception\Api;

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Exception;

--- a/src/Exception/BuilderException.php
+++ b/src/Exception/BuilderException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Exception;

--- a/src/Exception/DataTypeException.php
+++ b/src/Exception/DataTypeException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Exception;

--- a/src/Exception/RepositoryException.php
+++ b/src/Exception/RepositoryException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Exception;

--- a/src/Exception/TransactionException.php
+++ b/src/Exception/TransactionException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Exception;

--- a/src/Exception/WebhookException.php
+++ b/src/Exception/WebhookException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Exception;

--- a/src/Infrastructure/ApiConnection.php
+++ b/src/Infrastructure/ApiConnection.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 // phpcs:disable ObjectCalisthenics.Metrics.MethodPerClassLimit.ObjectCalisthenics\Sniffs\Metrics\MethodPerClassLimitSniff

--- a/src/Infrastructure/Connection.php
+++ b/src/Infrastructure/Connection.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Infrastructure;

--- a/src/Infrastructure/XMLBrandRepository.php
+++ b/src/Infrastructure/XMLBrandRepository.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Infrastructure;

--- a/src/etc/brands.xml
+++ b/src/etc/brands.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
-  ~ @license see LICENCE.TXT
+  ~ @license see LICENSE.txt
   -->
 <brands xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="./brands.xsd">

--- a/src/etc/brands.xsd
+++ b/src/etc/brands.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
-  ~ @license see LICENCE.TXT
+  ~ @license see LICENSE.txt
   -->
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:element name="category" type="categoryType"/>

--- a/tests/Test/Api/IDealTest.php
+++ b/tests/Test/Api/IDealTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Test\Api;

--- a/tests/Test/Unit/Application/Request/BuilderTest.php
+++ b/tests/Test/Unit/Application/Request/BuilderTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Test\Unit\Application\Request;

--- a/tests/Test/Unit/Application/Response/Fake.php
+++ b/tests/Test/Unit/Application/Response/Fake.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 declare(strict_types=1);

--- a/tests/Test/Unit/Application/Webhook/Service/EventBuilderTest.php
+++ b/tests/Test/Unit/Application/Webhook/Service/EventBuilderTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Test\Test\Unit\Application\Webhook\Service;

--- a/tests/Test/Unit/DataType/AmountTest.php
+++ b/tests/Test/Unit/DataType/AmountTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Test\Unit\DataType;

--- a/tests/Test/Unit/DataType/CountryCodeTest.php
+++ b/tests/Test/Unit/DataType/CountryCodeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Test\Unit\DataType;

--- a/tests/Test/Unit/DataType/CurrencyCodeTest.php
+++ b/tests/Test/Unit/DataType/CurrencyCodeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Test\Unit\DataType;

--- a/tests/Test/Unit/DataType/LanguageCodeTest.php
+++ b/tests/Test/Unit/DataType/LanguageCodeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Test\Unit\DataType;

--- a/tests/Test/Unit/DataType/LimitedStringTest.php
+++ b/tests/Test/Unit/DataType/LimitedStringTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Test\Unit\DataType;

--- a/tests/Test/Unit/DataType/UrlTest.php
+++ b/tests/Test/Unit/DataType/UrlTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Test\Unit\DataType;

--- a/tests/Test/Unit/Domain/Webhook/Service/EventDecoratorTest.php
+++ b/tests/Test/Unit/Domain/Webhook/Service/EventDecoratorTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Test\Test\Unit\Domain\Webhook\Service;

--- a/tests/Test/Unit/Domain/Webhook/Service/ValidatorTest.php
+++ b/tests/Test/Unit/Domain/Webhook/Service/ValidatorTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Test\Unit\Domain\Webhook\Service;

--- a/tests/Test/Unit/Infrastructure/XMLBrandRepositoryTest.php
+++ b/tests/Test/Unit/Infrastructure/XMLBrandRepositoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Test\Unit\Infrastructure;

--- a/tests/Test/Unit/Infrastructure/XMLIssuerRepositoryTest.php
+++ b/tests/Test/Unit/Infrastructure/XMLIssuerRepositoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
- * @license see LICENCE.TXT
+ * @license see LICENSE.txt
  */
 
 namespace Payvision\SDK\Test\Unit\Infrastructure;

--- a/tests/etc/brands.xml
+++ b/tests/etc/brands.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ @copyright Copyright (c) 2018-2019 Payvision B.V. (https://www.payvision.com/)
-  ~ @license see LICENCE.TXT
+  ~ @license see LICENSE.txt
   -->
 <brands xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="./../../src/etc/brands.xsd">


### PR DESCRIPTION
- [ ] I noticed a file was missing the `-2019` text
- [ ] All license links in docs are pointing to a non-existant LICENCE.TXT file